### PR TITLE
Fixed bug in runifcor.cor when length of x is not 1000.

### DIFF
--- a/R/correlatedsamplers.R
+++ b/R/correlatedsamplers.R
@@ -169,7 +169,7 @@ runifcor.cor <- function(x, rho){
     tmp <- (3-sqrt(1+8*abs(r)))/4 
     return(tmp * sign(r))
   } 
-  y <- (x*sign(rho) + runif(1000,-hw(abs(rho)),hw(rho*sign(rho)))) %% 1 
+  y <- (x*sign(rho) + runif(length(x),-hw(abs(rho)),hw(rho*sign(rho)))) %% 1 
   return(y)
 }
 


### PR DESCRIPTION
runifcor.cor is set up to assume a fixed length of 1000 for x. As a result the following code does not work:

```
library(datasynthR)
income_quantile = runif(50, 0, 1)
wealth_quantile = runifcor.cor(income_quantile, rho=0.7)
```

This small patch fixes the function.